### PR TITLE
Remove `hash_index_cells_used` metric and graphdef

### DIFF
--- a/lib/mysql.go
+++ b/lib/mysql.go
@@ -520,7 +520,6 @@ func (m *MySQLPlugin) addGraphdefWithInnoDBMetrics(graphdef map[string]mp.Graphs
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "hash_index_cells_total", Label: "Hash Index Cells Total", Diff: false, Stacked: false},
-			{Name: "hash_index_cells_used", Label: "Hash Index Cells Used", Diff: false, Stacked: false},
 		},
 	}
 	graphdef["innodb_buffer_pool_read"] = mp.Graphs{

--- a/lib/mysql.go
+++ b/lib/mysql.go
@@ -1020,11 +1020,6 @@ func parseInnodbStatus(str string, p map[string]float64) {
 		}
 		if strings.HasPrefix(line, "Hash table size ") {
 			setMap(p, "hash_index_cells_total", record[3])
-			if strings.Contains(line, "used cells") {
-				setMap(p, "hash_index_cells_used", record[6])
-			} else {
-				p["hash_index_cells_used"] = 0
-			}
 			continue
 		}
 

--- a/lib/mysql_test.go
+++ b/lib/mysql_test.go
@@ -255,7 +255,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["ibuf_merges"], 0)
 	assert.EqualValues(t, stat["ibuf_merged"], 0)
 	assert.EqualValues(t, stat["hash_index_cells_total"], 276671)
-	assert.EqualValues(t, stat["hash_index_cells_used"], 0)
 	// Log
 	assert.EqualValues(t, stat["log_writes"], 12)
 	assert.EqualValues(t, stat["pending_log_writes"], 0)
@@ -435,7 +434,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["ibuf_merges"], 348)
 	assert.EqualValues(t, stat["ibuf_merged"], 396)
 	assert.EqualValues(t, stat["hash_index_cells_total"], 2699)
-	assert.EqualValues(t, stat["hash_index_cells_used"], 0)
 	// Log
 	assert.EqualValues(t, stat["log_writes"], 7498)
 	assert.EqualValues(t, stat["pending_log_writes"], 0)
@@ -626,7 +624,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["ibuf_merges"], 0)
 	assert.EqualValues(t, stat["ibuf_merged"], 0)
 	assert.EqualValues(t, stat["hash_index_cells_total"], 276671)
-	assert.EqualValues(t, stat["hash_index_cells_used"], 0)
 	// Log
 	assert.EqualValues(t, stat["log_writes"], 40)
 	assert.EqualValues(t, stat["pending_log_writes"], 10)

--- a/tests/extend-mysql8/rule_mysql8_extend.txt
+++ b/tests/extend-mysql8/rule_mysql8_extend.txt
@@ -132,7 +132,6 @@ mysql.innodb_memory_allocation.total_mem_alloc	>=0
 mysql.innodb_semaphores.spin_waits	>=0
 mysql.innodb_semaphores.os_waits	>=0
 mysql.innodb_adaptive_hash_index.hash_index_cells_total	>=0
-mysql.innodb_adaptive_hash_index.hash_index_cells_used	>=0
 mysql.innodb_buffer_pool_efficiency.Innodb_buffer_pool_reads	>=0
 mysql.innodb_buffer_pool_efficiency.Innodb_buffer_pool_read_requests	>=0
 ~mysql.seconds_behind_master.Seconds_Behind_Master	>=0

--- a/tests/read-replica-mysql8/rule.txt
+++ b/tests/read-replica-mysql8/rule.txt
@@ -67,7 +67,6 @@ mysql.threads.Threads_cached	>=0
 mysql.innodb_buffer_pool_efficiency.Innodb_buffer_pool_reads	>=0
 mysql.innodb_buffer_pool_efficiency.Innodb_buffer_pool_read_requests	>=0
 mysql.innodb_adaptive_hash_index.hash_index_cells_total	>=0
-mysql.innodb_adaptive_hash_index.hash_index_cells_used	>=0
 mysql.innodb_transactions_active_locked.current_transactions	>=0
 mysql.innodb_transactions_active_locked.read_views	>=0
 mysql.innodb_buffer_pool_activity.pages_created	>=0


### PR DESCRIPTION
## WHY

According to #11, `hash_index_cells_used` is no longer available from unsupported version 5.1.28.

## WHAT

Remove `hash_index_cells_used` metric and graphdef

## NOTE

See also
- 8.0: https://dev.mysql.com/doc/refman/8.0/en/innodb-standard-monitor.html
- 5.7: https://dev.mysql.com/doc/refman/5.7/en/innodb-standard-monitor.html
