### PR TITLE
Upgrade Go 1.22 and 1.21 by reusable workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -6,5 +6,4 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
 jobs:
   goreleaser:
-    uses: mackerelio/workflows/.github/workflows/goreleaser.yml@main
-
+    uses: mackerelio/workflows/.github/workflows/goreleaser.yml@v1.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,33 +12,12 @@ env:
   DEBIAN_FRONTEND: noninteractive
 jobs:
   lint:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: golangci/golangci-lint-action@v3
-        with:
-          args: --timeout 2m
+    uses: mackerelio/workflows/.github/workflows/go-lint.yml@v1.1.0
   test:
-    strategy:
-      matrix:
-        go: ["1.19.x", "1.18.x"]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - run: |
-        make test
-    - run: |
-        ./test.sh
+    uses: mackerelio/workflows/.github/workflows/go-test.yml@v1.1.0
+  testci:
+    uses: mackerelio/workflows/.github/workflows/setup-go-matrix.yml@v1.1.0
+    with:
+      os-versions: '["ubuntu-22.04"]'
+      run: |
+        make testci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ name: test
 on:
   push:
     branches:
-    - master
+    - main
     tags:
     - v*
   pull_request:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@ build:
 	go build -o mackerel-plugin-mysql
 
 .PHONY: test
-test: testgo build
+test: testgo build testci
+
+.PHONY: testci
+testci:
 	go install github.com/lufia/graphitemetrictest/cmd/graphite-metric-test@latest
 	./test.sh
 


### PR DESCRIPTION
I rewrite test workflow.

This plugin needs integration tests, written in test.sh, so I decided to keep `make test` in the workflow.