### PR TITLE
Replace command of fetching replica status for MySQL 8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ command = "/path/to/mackerel-plugin-mysql"
 
 ## Supported MySQL version
 
+- `v1.3.0 >=` mysql 5.7, 8.0, 8.4 and above
 - `v1.1.0 >=` mysql 5.7, 8.0
 - `v1.0.0` mysql 5.0, 5.1, 5.5, 5.6, 5.7, 8.0

--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ command = "/path/to/mackerel-plugin-mysql"
 
 ## Supported MySQL version
 
-- `v1.1.0 >=` mysql 5.7, 8.0 and above
+- `v1.1.0 >=` mysql 5.7, 8.0
 - `v1.0.0` mysql 5.0, 5.1, 5.5, 5.6, 5.7, 8.0

--- a/lib/mysql.go
+++ b/lib/mysql.go
@@ -298,10 +298,12 @@ func fetchShowVariablesBackwardCompatibile(stat map[string]float64) error {
 // This code does not work with multi-source replication.
 func (m *MySQLPlugin) fetchShowReplicaStatus(db *sql.DB, stat map[string]float64, version [3]int) error {
 	command := "show replica status"
+	secondsBehindSourceColumn := "Seconds_Behind_Source"
 	if version[0] < 8 || (version[0] == 8 && version[1] == 0 && version[2] < 22) {
 		// From MySQL 8.0.22, SHOW RELICA STATUS command is created and SHOW SLAVE STATUS command is deprecated.
 		// cf.) https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-22.html
 		command = "show slave status"
+		secondsBehindSourceColumn = "Seconds_Behind_Master"
 	}
 	rows, err := db.Query(command)
 	if err != nil {
@@ -326,7 +328,7 @@ func (m *MySQLPlugin) fetchShowReplicaStatus(db *sql.DB, stat map[string]float64
 		for i, column := range columns {
 			variableName := column.Name()
 			value := values[i]
-			if variableName == "Seconds_Behind_Master" {
+			if variableName == secondsBehindSourceColumn {
 				if value != nil {
 					f, err := atof(string(value))
 					if err != nil {

--- a/lib/mysql.go
+++ b/lib/mysql.go
@@ -305,13 +305,13 @@ func (m *MySQLPlugin) fetchShowReplicaStatus(db *sql.DB, stat map[string]float64
 	}
 	rows, err := db.Query(command)
 	if err != nil {
-		return fmt.Errorf("FetchMetrics (Slave Status): %w", err)
+		return fmt.Errorf("FetchMetrics (Replica Status): %w", err)
 	}
 	defer rows.Close()
 	for rows.Next() {
 		columns, err := rows.ColumnTypes()
 		if err != nil {
-			return fmt.Errorf("FetchMetrics (Slave Status): %w", err)
+			return fmt.Errorf("FetchMetrics (Replica Status): %w", err)
 		}
 
 		valuePtrs := make([]interface{}, len(columns))
@@ -321,7 +321,7 @@ func (m *MySQLPlugin) fetchShowReplicaStatus(db *sql.DB, stat map[string]float64
 			valuePtrs[i] = &values[i]
 		}
 		if err = rows.Scan(valuePtrs...); err != nil {
-			return fmt.Errorf("FetchMetrics (Slave Status): %w", err)
+			return fmt.Errorf("FetchMetrics (Replica Status): %w", err)
 		}
 		for i, column := range columns {
 			variableName := column.Name()

--- a/tests/extend-mysql8/test.sh
+++ b/tests/extend-mysql8/test.sh
@@ -25,7 +25,7 @@ docker run -d \
 	--name "test-$plugin" \
 	-p $port:3306 \
 	-e MYSQL_ROOT_PASSWORD=$password \
-	"$image" --default-authentication-plugin=mysql_native_password
+	"$image"
 trap 'docker stop test-$plugin; docker rm test-$plugin; exit' 1 2 3 15 EXIT
 sleep 10
 

--- a/tests/read-replica-mysql8/sourcedb/init.d/init.sql
+++ b/tests/read-replica-mysql8/sourcedb/init.d/init.sql
@@ -1,2 +1,2 @@
 CREATE USER 'replica'@'%' IDENTIFIED BY 'replica';
-GRANT REPLICATION ON *.* TO 'replica'@'%';
+GRANT REPLICATION SLAVE ON *.* TO 'replica'@'%';

--- a/tests/read-replica-mysql8/sourcedb/init.d/init.sql
+++ b/tests/read-replica-mysql8/sourcedb/init.d/init.sql
@@ -1,2 +1,2 @@
 CREATE USER 'replica'@'%' IDENTIFIED BY 'replica';
-GRANT REPLICATION SLAVE ON *.* TO 'replica'@'%';
+GRANT REPLICATION ON *.* TO 'replica'@'%';


### PR DESCRIPTION
`SHOW SLAVE STATUS` command was deprecated in MySQL 8.0, but has been removed in 8.4. In other words, mackerel-plugin-mysql calling this command cannot work with MySQL 8.4.

This pull request makes the plugin to call `SHOW REPLICA STATUS` command instead of `SHOW SLAVE STATUS` if MySQL version is 8.0.22 or later.

I also fixed a test script that fails because MySQL container for testing had moved up to 8.4.
